### PR TITLE
PT-9091: Created date in Content is not corresponding to the creation date

### DIFF
--- a/VirtoCommerce.FileSystemAssetsModule.sln
+++ b/VirtoCommerce.FileSystemAssetsModule.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29123.88
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32630.192
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{4FD6A475-8E27-4933-A76F-38CD0A10663F}"
 EndProject

--- a/src/VirtoCommerce.FileSystemAssetsModule.Core/FileSystemBlobProvider.cs
+++ b/src/VirtoCommerce.FileSystemAssetsModule.Core/FileSystemBlobProvider.cs
@@ -71,6 +71,7 @@ namespace VirtoCommerce.FileSystemAssetsModule.Core
                 result.ContentType = MimeTypeResolver.ResolveContentType(fileInfo.Name);
                 result.Size = fileInfo.Length;
                 result.Name = fileInfo.Name;
+                result.CreatedDate = fileInfo.CreationTimeUtc;
                 result.ModifiedDate = fileInfo.LastWriteTimeUtc;
                 result.RelativeUrl = GetRelativeUrl(result.Url);
             }
@@ -156,6 +157,8 @@ namespace VirtoCommerce.FileSystemAssetsModule.Core
                 folder.Url = GetAbsoluteUrlFromPath(directory);
                 folder.ParentUrl = GetAbsoluteUrlFromPath(directoryInfo.Parent?.FullName);
                 folder.RelativeUrl = GetRelativeUrl(folder.Url);
+                folder.CreatedDate = directoryInfo.CreationTimeUtc;
+                folder.ModifiedDate = directoryInfo.LastWriteTimeUtc;
                 result.Results.Add(folder);
             }
 
@@ -169,6 +172,7 @@ namespace VirtoCommerce.FileSystemAssetsModule.Core
                 blobInfo.ContentType = MimeTypeResolver.ResolveContentType(fileInfo.Name);
                 blobInfo.Size = fileInfo.Length;
                 blobInfo.Name = fileInfo.Name;
+                blobInfo.CreatedDate = fileInfo.CreationTimeUtc;
                 blobInfo.ModifiedDate = fileInfo.LastWriteTimeUtc;
                 blobInfo.RelativeUrl = GetRelativeUrl(blobInfo.Url);
                 result.Results.Add(blobInfo);

--- a/src/VirtoCommerce.FileSystemAssetsModule.Web/module.manifest
+++ b/src/VirtoCommerce.FileSystemAssetsModule.Web/module.manifest
@@ -16,7 +16,7 @@
   <iconUrl>Modules/$(VirtoCommerce.FileSystemAssetsModule)/Content/logo.png</iconUrl>
   <requireLicenseAcceptance>false</requireLicenseAcceptance>
   <releaseNotes />
-  <copyright>Copyright © 2021 Virto Commerce. All rights reserved</copyright>
+  <copyright>Copyright © 2022 Virto Commerce. All rights reserved</copyright>
   <tags>assets</tags>
   <assemblyFile>VirtoCommerce.FileSystemAssetsModule.Web.dll</assemblyFile>
   <moduleType>VirtoCommerce.FileSystemAssetsModule.Web.Module, VirtoCommerce.FileSystemAssetsModule.Web</moduleType>


### PR DESCRIPTION
## Description
fix: Empty Created and Modified Date for Assets and Folders

## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/PT-9091
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.FileSystemAssets_3.201.0-pr-4-f2f6.zip
