### PR TITLE
VCST-1385: External link encoded after saving

### DIFF
--- a/src/VirtoCommerce.FileSystemAssetsModule.Core/FileSystemBlobProvider.cs
+++ b/src/VirtoCommerce.FileSystemAssetsModule.Core/FileSystemBlobProvider.cs
@@ -347,8 +347,6 @@ namespace VirtoCommerce.FileSystemAssetsModule.Core
         {
             ArgumentNullException.ThrowIfNull(nameof(inputUrl));
 
-            var baseUri = new Uri(_basePublicUrl + '/', UriKind.Absolute);
-
             // do trim lead slash to prevent transform it to absolute file path on linux.
             if (Uri.TryCreate(inputUrl.TrimStart('/'), UriKind.Absolute, out var resultUri))
             {
@@ -365,6 +363,7 @@ namespace VirtoCommerce.FileSystemAssetsModule.Core
                 inputUrl = "./" + inputUrl;
             }
 
+            var baseUri = new Uri(_basePublicUrl + '/', UriKind.Absolute);
             if (Uri.TryCreate(baseUri, inputUrl, out resultUri))
             {
                 // If the input URL is relative, combine it with the base URI

--- a/src/VirtoCommerce.FileSystemAssetsModule.Core/FileSystemBlobProvider.cs
+++ b/src/VirtoCommerce.FileSystemAssetsModule.Core/FileSystemBlobProvider.cs
@@ -349,9 +349,8 @@ namespace VirtoCommerce.FileSystemAssetsModule.Core
 
             var baseUri = new Uri(_basePublicUrl + '/', UriKind.Absolute);
 
-            inputUrl = inputUrl.TrimStart('/');
-
-            if (Uri.TryCreate(inputUrl, UriKind.Absolute, out var resultUri))
+            // do trim lead slash to prevent transform it to absolute file path on linux.
+            if (Uri.TryCreate(inputUrl.TrimStart('/'), UriKind.Absolute, out var resultUri))
             {
                 // If the input URL is already absolute, return it as is (with correct encoding)
                 return resultUri.AbsoluteUri;

--- a/src/VirtoCommerce.FileSystemAssetsModule.Core/FileSystemBlobProvider.cs
+++ b/src/VirtoCommerce.FileSystemAssetsModule.Core/FileSystemBlobProvider.cs
@@ -343,19 +343,34 @@ namespace VirtoCommerce.FileSystemAssetsModule.Core
 
         #region IBlobUrlResolver Members
 
-        public virtual string GetAbsoluteUrl(string blobKey)
+        public virtual string GetAbsoluteUrl(string inputUrl)
         {
-            if (blobKey == null)
+            ArgumentNullException.ThrowIfNull(nameof(inputUrl));
+
+            var baseUri = new Uri(_basePublicUrl + '/', UriKind.Absolute);
+
+            if (Uri.TryCreate(inputUrl, UriKind.Absolute, out var resultUri))
             {
-                throw new ArgumentNullException(nameof(blobKey));
+                // If the input URL is already absolute, return it as is (with correct encoding)
+                return resultUri.AbsoluteUri;
             }
 
-            var result = EscapeUri(blobKey);
-            if (!blobKey.IsAbsoluteUrl())
+            if (inputUrl.StartsWith('/'))
             {
-                result = _basePublicUrl + "/" + result.TrimStart('/').TrimEnd('/');
+                inputUrl = "." + inputUrl;
             }
-            return new Uri(result).ToString();
+            else if (!inputUrl.StartsWith('.'))
+            {
+                inputUrl = "./" + inputUrl;
+            }
+
+            if (Uri.TryCreate(baseUri, inputUrl, out resultUri))
+            {
+                // If the input URL is relative, combine it with the base URI
+                return resultUri.AbsoluteUri;
+            }
+
+            return inputUrl;
         }
 
         #endregion IBlobUrlResolver Members
@@ -415,16 +430,6 @@ namespace VirtoCommerce.FileSystemAssetsModule.Core
             {
                 throw new PlatformException($"Invalid path {path}");
             }
-        }
-
-        private static string EscapeUri(string stringToEscape)
-        {
-            // Escape only file name because Uri.EscapeDataString() escapes slashes, which we don't want
-            var fileName = Path.GetFileName(stringToEscape);
-            var blobPath = string.IsNullOrEmpty(fileName) ? stringToEscape : stringToEscape.Replace(fileName, string.Empty);
-            var escapedFileName = Uri.EscapeDataString(fileName);
-
-            return $"{blobPath}{escapedFileName}";
         }
     }
 }

--- a/src/VirtoCommerce.FileSystemAssetsModule.Core/FileSystemBlobProvider.cs
+++ b/src/VirtoCommerce.FileSystemAssetsModule.Core/FileSystemBlobProvider.cs
@@ -349,6 +349,8 @@ namespace VirtoCommerce.FileSystemAssetsModule.Core
 
             var baseUri = new Uri(_basePublicUrl + '/', UriKind.Absolute);
 
+            inputUrl = inputUrl.TrimStart('/');
+
             if (Uri.TryCreate(inputUrl, UriKind.Absolute, out var resultUri))
             {
                 // If the input URL is already absolute, return it as is (with correct encoding)

--- a/tests/VirtoCommerce.Platform.Assets.FileSystem.Tests/FileSystemBlobStorageProviderTests.cs
+++ b/tests/VirtoCommerce.Platform.Assets.FileSystem.Tests/FileSystemBlobStorageProviderTests.cs
@@ -144,8 +144,6 @@ namespace VirtoCommerce.Platform.Tests.Assets
         [InlineData("https://localhost:5001/assets/catalog/151349/epson%20printer.txt?test=Name%20With%20Space", "https://localhost:5001/assets/catalog/151349/epson%20printer.txt?test=Name%20With%20Space")]
         public void GetAbsoluteUrlTest(string blobKey, string absoluteUrl)
         {
-            Assert.Equal(_options.Value.PublicUrl, "https://localhost:5001/assets");
-
             var mockFileExtensionService = new Mock<IFileExtensionService>();
             mockFileExtensionService.Setup(service => service.IsExtensionAllowedAsync(It.IsAny<string>())).ReturnsAsync(true);
 

--- a/tests/VirtoCommerce.Platform.Assets.FileSystem.Tests/FileSystemBlobStorageProviderTests.cs
+++ b/tests/VirtoCommerce.Platform.Assets.FileSystem.Tests/FileSystemBlobStorageProviderTests.cs
@@ -144,6 +144,8 @@ namespace VirtoCommerce.Platform.Tests.Assets
         [InlineData("https://localhost:5001/assets/catalog/151349/epson%20printer.txt?test=Name%20With%20Space", "https://localhost:5001/assets/catalog/151349/epson%20printer.txt?test=Name%20With%20Space")]
         public void GetAbsoluteUrlTest(string blobKey, string absoluteUrl)
         {
+            Assert.Equal(_options.Value.PublicUrl, "https://localhost:5001/assets");
+
             var mockFileExtensionService = new Mock<IFileExtensionService>();
             mockFileExtensionService.Setup(service => service.IsExtensionAllowedAsync(It.IsAny<string>())).ReturnsAsync(true);
 


### PR DESCRIPTION
## Description
fix: Resolves issue with External link encoded after saving

## References
### QA-test:
### Jira-link:



https://virtocommerce.atlassian.net/browse/VCST-1385
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.FileSystemAssets_3.803.0-pr-9-610f.zip