### PR TITLE
VCST-4328: Update to .NET10

### DIFF
--- a/.nuke
+++ b/.nuke
@@ -1,1 +1,0 @@
-VirtoCommerce.FileSystemAssetsModule.sln

--- a/.nuke/parameters.json
+++ b/.nuke/parameters.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "./build.schema.json",
+  "Solution": "VirtoCommerce.FileSystemAssetsModule.sln"
+}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <!-- These properties will be shared for all projects -->
   <PropertyGroup>
-    <VersionPrefix>3.809.0</VersionPrefix>
+    <VersionPrefix>3.1000.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' != '' AND '$(BuildNumber)' != '' ">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
   </PropertyGroup>

--- a/src/VirtoCommerce.FileSystemAssetsModule.Core/FileSystemBlobProvider.cs
+++ b/src/VirtoCommerce.FileSystemAssetsModule.Core/FileSystemBlobProvider.cs
@@ -32,7 +32,7 @@ namespace VirtoCommerce.FileSystemAssetsModule.Core
         public FileSystemBlobProvider(
            IOptions<FileSystemBlobOptions> options,
            IFileExtensionService fileExtensionService,
-           IEventPublisher eventPublisher): this(options, fileExtensionService, eventPublisher, NullLogger<FileSystemBlobProvider>.Instance)
+           IEventPublisher eventPublisher) : this(options, fileExtensionService, eventPublisher, NullLogger<FileSystemBlobProvider>.Instance)
         {
         }
 
@@ -388,7 +388,7 @@ namespace VirtoCommerce.FileSystemAssetsModule.Core
 
         public virtual string GetAbsoluteUrl(string inputUrl)
         {
-            ArgumentNullException.ThrowIfNull(nameof(inputUrl));
+            ArgumentNullException.ThrowIfNull(inputUrl);
 
             // do trim lead slash to prevent transform it to absolute file path on linux.
             if (Uri.TryCreate(inputUrl.TrimStart('/'), UriKind.Absolute, out var resultUri))

--- a/src/VirtoCommerce.FileSystemAssetsModule.Core/VirtoCommerce.FileSystemAssetsModule.Core.csproj
+++ b/src/VirtoCommerce.FileSystemAssetsModule.Core/VirtoCommerce.FileSystemAssetsModule.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <noWarn>1591</noWarn>
     <IsPackable>True</IsPackable>
@@ -13,8 +13,7 @@
     <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="Polly" Version="8.5.0" />
-    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.814.0" />
+    <PackageReference Include="Polly" Version="8.6.5" />
+    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.1000.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.FileSystemAssetsModule.Web/VirtoCommerce.FileSystemAssetsModule.Web.csproj
+++ b/src/VirtoCommerce.FileSystemAssetsModule.Web/VirtoCommerce.FileSystemAssetsModule.Web.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <noWarn>1591</noWarn>
     <OutputType>Library</OutputType>

--- a/src/VirtoCommerce.FileSystemAssetsModule.Web/module.manifest
+++ b/src/VirtoCommerce.FileSystemAssetsModule.Web/module.manifest
@@ -21,7 +21,7 @@
   <iconUrl>Modules/$(VirtoCommerce.FileSystemAssetsModule)/Content/logo.png</iconUrl>
   <requireLicenseAcceptance>false</requireLicenseAcceptance>
   <releaseNotes />
-  <copyright>Copyright © 2011-2025 Virto Commerce. All rights reserved</copyright>
+  <copyright>Copyright © 2011-2026 Virto Commerce. All rights reserved</copyright>
   <tags>assets</tags>
   <assemblyFile>VirtoCommerce.FileSystemAssetsModule.Web.dll</assemblyFile>
   <moduleType>VirtoCommerce.FileSystemAssetsModule.Web.Module, VirtoCommerce.FileSystemAssetsModule.Web</moduleType>

--- a/src/VirtoCommerce.FileSystemAssetsModule.Web/module.manifest
+++ b/src/VirtoCommerce.FileSystemAssetsModule.Web/module.manifest
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <id>VirtoCommerce.FileSystemAssets</id>
-  <version>3.809.0</version>
+  <version>3.1000.0</version>
   <version-tag />
 
-  <platformVersion>3.917.0</platformVersion>
+  <platformVersion>3.1002.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Assets" version="3.814.0" />
+    <dependency id="VirtoCommerce.Assets" version="3.1000.0" />
   </dependencies>
 
   <title>File Systems Assets Provider</title>

--- a/tests/VirtoCommerce.Platform.Assets.FileSystem.Tests/FileSystemBlobStorageProviderTests.cs
+++ b/tests/VirtoCommerce.Platform.Assets.FileSystem.Tests/FileSystemBlobStorageProviderTests.cs
@@ -1,9 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -105,7 +103,7 @@ namespace VirtoCommerce.Platform.Tests.Assets
             var filePath = Path.Combine(_tempDirectory, fileName);
 
             // Create a file with some content
-            await File.WriteAllTextAsync(filePath, "test content");
+            await File.WriteAllTextAsync(filePath, "test content", TestContext.Current.CancellationToken);
 
             FileStream lockingStream = null;
             Stream resultStream = null;
@@ -121,7 +119,7 @@ namespace VirtoCommerce.Platform.Tests.Assets
                     await Task.Delay(100); // Release after 100ms (should trigger 1-2 retries)
                     lockingStream?.Dispose();
                     lockingStream = null;
-                });
+                }, TestContext.Current.CancellationToken);
 
                 // Act - This should retry and eventually succeed after the lock is released
                 resultStream = await fsbProvider.OpenReadAsync(fileName);
@@ -166,7 +164,7 @@ namespace VirtoCommerce.Platform.Tests.Assets
             var filePath = Path.Combine(_tempDirectory, fileName);
 
             // Create a file with some content
-            await File.WriteAllTextAsync(filePath, "test content");
+            await File.WriteAllTextAsync(filePath, "test content", TestContext.Current.CancellationToken);
 
             FileStream lockingStream = null;
 

--- a/tests/VirtoCommerce.Platform.Assets.FileSystem.Tests/VirtoCommerce.FileSystemAssetsModule.Tests.csproj
+++ b/tests/VirtoCommerce.Platform.Assets.FileSystem.Tests/VirtoCommerce.FileSystemAssetsModule.Tests.csproj
@@ -1,18 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <UserSecretsId>local</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Description
Update to .NET10

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4328
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.FileSystemAssets_3.1000.0-pr-15-a222.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad runtime/tooling upgrade to `net10.0` plus dependency/test framework bumps; main risk is build/test incompatibilities or behavioral changes in updated libraries rather than functional logic changes.
> 
> **Overview**
> Updates the module (core, web, and tests) to target `net10.0`, and bumps the module/version metadata to `3.1000.0` with updated platform/assets dependency versions.
> 
> Refreshes dependencies/tooling: upgrades `Polly` and the VirtoCommerce Assets dependency, modernizes the test stack (newer `Microsoft.NET.Test.Sdk`, `xunit.v3`, updated runner/coverlet), and adjusts tests to pass `TestContext.Current.CancellationToken` to async file/task operations. Also adds `.nuke/parameters.json` to centralize the solution path and fixes a null-check bug in `FileSystemBlobProvider.GetAbsoluteUrl` (`ThrowIfNull(inputUrl)`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2222209794f71aa2fa369393e1e0d6fbc74a00b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->