### PR TITLE
VCST-5163: Stable 15 — FileSystemAssets (platform 3.1039.0)

### DIFF
--- a/src/VirtoCommerce.FileSystemAssetsModule.Core/VirtoCommerce.FileSystemAssetsModule.Core.csproj
+++ b/src/VirtoCommerce.FileSystemAssetsModule.Core/VirtoCommerce.FileSystemAssetsModule.Core.csproj
@@ -14,6 +14,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Polly" Version="8.6.5" />
-    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.1005.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.FileSystemAssetsModule.Web/module.manifest
+++ b/src/VirtoCommerce.FileSystemAssetsModule.Web/module.manifest
@@ -4,9 +4,9 @@
   <version>3.1003.0</version>
   <version-tag />
 
-  <platformVersion>3.1002.0</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Assets" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Assets" version="3.1005.0" />
   </dependencies>
 
   <title>File Systems Assets Provider</title>


### PR DESCRIPTION
Part of **Stable 15** (Wave 2). Builds against published platform [3.1039.0](https://github.com/VirtoCommerce/vc-platform/releases/tag/3.1039.0) + Wave-1 packages on nuget.org. Version is left for CI to increment at release.

- Platform -> **3.1039.0**; Wave-1 deps -> released versions.
- `vc-build Compress` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only dependency and manifest updates with no runtime logic changes; main risk is mismatched platform/module versions if upstream packages behave differently.
> 
> **Overview**
> **Stable 15 / Wave 2** alignment only: bumps the module’s platform and Wave-1 package pins with no application code changes.
> 
> `module.manifest` now targets **platform 3.1039.0** (was 3.1002.0) and declares **VirtoCommerce.Assets 3.1005.0** (was 3.1000.0). The Core project’s **VirtoCommerce.AssetsModule.Core** NuGet reference is updated to **3.1005.0** to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb0f0b0191f9285f30b04c7251051d68d8fb8f50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5163
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.FileSystemAssets_3.1003.0-pr-16-fb0f.zip